### PR TITLE
Minor fix

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -8,6 +8,7 @@
     - python-lockfile
     - python-paramiko
     - python-daemon
+    - python-devel
     - logrotate
 
 - name: Install pip packages


### PR DESCRIPTION
* add installation of python-devel in packages.yml
the installation of zuul fails due to missing python.h header file, adding python-devel in packages.yml.

